### PR TITLE
.2059806565729300:fb2bf2a22b1f5dc83e70285cbb486527_69de061a949d52b384860bc4.69e3a869b13256d09ece82c4.69e3a869dc688667809240d7:Trae CN.T(2026/4/18 23:51:05)

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -24,11 +24,11 @@ class DocumentsController < ApplicationController
       @file_name = nil
     else
       @file_name = SecureRandom.uuid + '.pdf'
+      data = @file.read
 
       if @encrypted
         lockbox = Lockbox.new(key: current_user.secret_key)
 
-        data = @file.read
         encrypted_data = lockbox.encrypt(data)
         File.write(Settings.document_folder + @file_name, encrypted_data, mode: 'w+b')
       else

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -21,35 +21,52 @@ class DocumentsController < ApplicationController
     @encrypted = current_user.encryption_actived_flag? and current_user.secret_key.present?
 
     if @file.blank?
-      @file_name = nil
+      json_response({ message: "Document file is required" }, :unprocessable_entity)
+      return
+    end
+
+    data = @file.read
+    if data.nil? || data.empty?
+      json_response({ message: "Document file cannot be empty" }, :unprocessable_entity)
+      return
+    end
+
+    content_type = @file.content_type.to_s
+    original_filename = @file.original_filename.to_s
+    is_pdf = content_type == 'application/pdf' || 
+             content_type == 'application/octet-stream' ||
+             original_filename.end_with?('.pdf')
+
+    unless is_pdf
+      json_response({ message: "Only PDF documents are allowed" }, :unprocessable_entity)
+      return
+    end
+
+    @file_name = SecureRandom.uuid + '.pdf'
+
+    if @encrypted
+      lockbox = Lockbox.new(key: current_user.secret_key)
+      encrypted_data = lockbox.encrypt(data)
+      File.write(Settings.document_folder + @file_name, encrypted_data, mode: 'w+b')
+      @file_text = ""
     else
-      @file_name = SecureRandom.uuid + '.pdf'
-      data = @file.read
+      File.write(Settings.document_folder + @file_name, data, mode: 'w+b')
 
-      if @encrypted
-        lockbox = Lockbox.new(key: current_user.secret_key)
+      begin
+        reader = PDF::Reader.new(Settings.document_folder + @file_name)
+        reader.pages.each do |page|
+          @file_text = @file_text + page.text
+        end
 
-        encrypted_data = lockbox.encrypt(data)
-        File.write(Settings.document_folder + @file_name, encrypted_data, mode: 'w+b')
-      else
-        File.write(Settings.document_folder + @file_name, data, mode: 'w+b')
+        @file_text.delete!("\r\n")
+        @file_text.delete!("\n")
+        @file_text.delete!(' ')
 
-        begin
-          reader = PDF::Reader.new(Settings.document_folder + @file_name)
-          reader.pages.each do |page|
-            @file_text = @file_text + page.text
-          end
-
-          @file_text.delete!("\r\n")
-          @file_text.delete!("\n")
-          @file_text.delete!(' ')
-
-          if @file_text.bytesize > 65535
-            @file_text = ""
-          end
-        rescue PDF::Reader::MalformedPDFError, PDF::Reader::EncryptedPDFError
+        if @file_text.bytesize > 65535
           @file_text = ""
         end
+      rescue PDF::Reader::MalformedPDFError, PDF::Reader::EncryptedPDFError
+        @file_text = ""
       end
     end
 

--- a/test/controllers/documents_controller_test.rb
+++ b/test/controllers/documents_controller_test.rb
@@ -9,7 +9,7 @@ class DocumentsControllerTest < ActionController::TestCase
     @token_without_encryption = JsonWebToken.encode(user_id: @non_encrypted_user.id)
     @token_with_encryption = JsonWebToken.encode(user_id: @encrypted_user.id)
     
-    @test_pdf_content = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \ntrailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n192\n%%EOF"
+    @test_pdf_content = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>\nendobj\n4 0 obj\n<< /Length 44 >>\nstream\nBT\n/F1 24 Tf\n100 700 Td\n(Hello World) Tj\nET\nendstream\nendobj\nxref\n0 5\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \n0000000208 00000 n \ntrailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n310\n%%EOF"
   end
 
   test "should create document without encryption for non-encrypted user" do
@@ -84,10 +84,10 @@ class DocumentsControllerTest < ActionController::TestCase
     temp_file.unlink
   end
 
-  test "should create document without file (empty document)" do
+  test "should return 422 when document is not provided" do
     @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
     
-    assert_difference('Document.count') do
+    assert_no_difference('Document.count') do
       post :create, params: {
         title: 'Empty Document',
         description: 'Document without file',
@@ -95,12 +95,122 @@ class DocumentsControllerTest < ActionController::TestCase
       }
     end
     
+    assert_response :unprocessable_entity
+    
+    json_response = JSON.parse(@response.body)
+    assert_includes json_response['message'], 'required'
+  end
+
+  test "should return 422 when document file is empty" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    temp_file = Tempfile.new(['empty', '.pdf'])
+    temp_file.write('')
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_no_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Empty File Document',
+        description: 'Empty file',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :unprocessable_entity
+    
+    json_response = JSON.parse(@response.body)
+    assert_includes json_response['message'], 'empty'
+    
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "should return 422 when document is not a PDF" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.txt'])
+    temp_file.write('This is a text file, not a PDF')
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'text/plain')
+    
+    assert_no_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Text Document',
+        description: 'This is not a PDF',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :unprocessable_entity
+    
+    json_response = JSON.parse(@response.body)
+    assert_includes json_response['message'], 'PDF'
+    
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "non-encrypted document should have document_text extracted" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.pdf'])
+    temp_file.write(@test_pdf_content)
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Document With Text',
+        description: 'Test text extraction',
+        document_date: Date.today.to_s
+      }
+    end
+    
     assert_response :created
     
     new_document = Document.last
-    assert_equal 'Empty Document', new_document.title
-    assert_nil new_document.document_url
     assert_equal false, new_document.encrypted_flag
+    assert_not_empty new_document.document_text
+    
+    File.delete(Settings.document_folder + new_document.document_url) if File.exist?(Settings.document_folder + new_document.document_url)
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "encrypted document should have empty document_text" do
+    @request.headers['Authorization'] = "Bearer #{@token_with_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.pdf'])
+    temp_file.write(@test_pdf_content)
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Encrypted Document With Text',
+        description: 'Encrypted, text should be empty',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :created
+    
+    new_document = Document.last
+    assert_equal true, new_document.encrypted_flag
+    assert_empty new_document.document_text
+    
+    File.delete(Settings.document_folder + new_document.document_url) if File.exist?(Settings.document_folder + new_document.document_url)
+    temp_file.close
+    temp_file.unlink
   end
 
   test "should download non-encrypted document" do

--- a/test/controllers/documents_controller_test.rb
+++ b/test/controllers/documents_controller_test.rb
@@ -1,7 +1,163 @@
 require 'test_helper'
 
 class DocumentsControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @non_encrypted_user = users(:one)
+    @encrypted_user = users(:two)
+    @document = documents(:one)
+    
+    @token_without_encryption = JsonWebToken.encode(user_id: @non_encrypted_user.id)
+    @token_with_encryption = JsonWebToken.encode(user_id: @encrypted_user.id)
+    
+    @test_pdf_content = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \ntrailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n192\n%%EOF"
+  end
+
+  test "should create document without encryption for non-encrypted user" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.pdf'])
+    temp_file.write(@test_pdf_content)
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Test Document',
+        description: 'Test description',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :created
+    
+    new_document = Document.last
+    assert_equal false, new_document.encrypted_flag
+    assert_equal 'Test Document', new_document.title
+    
+    assert File.exist?(Settings.document_folder + new_document.document_url)
+    
+    stored_content = File.read(Settings.document_folder + new_document.document_url)
+    assert_equal @test_pdf_content, stored_content
+    
+    File.delete(Settings.document_folder + new_document.document_url) if File.exist?(Settings.document_folder + new_document.document_url)
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "should create document with encryption for encrypted user" do
+    @request.headers['Authorization'] = "Bearer #{@token_with_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.pdf'])
+    temp_file.write(@test_pdf_content)
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Encrypted Test Document',
+        description: 'Encrypted test description',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :created
+    
+    new_document = Document.last
+    assert_equal true, new_document.encrypted_flag
+    assert_equal 'Encrypted Test Document', new_document.title
+    
+    assert File.exist?(Settings.document_folder + new_document.document_url)
+    
+    stored_content = File.read(Settings.document_folder + new_document.document_url)
+    assert_not_equal @test_pdf_content, stored_content
+    
+    lockbox = Lockbox.new(key: @encrypted_user.secret_key)
+    decrypted_content = lockbox.decrypt(stored_content)
+    assert_equal @test_pdf_content, decrypted_content
+    
+    File.delete(Settings.document_folder + new_document.document_url) if File.exist?(Settings.document_folder + new_document.document_url)
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "should create document without file (empty document)" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        title: 'Empty Document',
+        description: 'Document without file',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :created
+    
+    new_document = Document.last
+    assert_equal 'Empty Document', new_document.title
+    assert_nil new_document.document_url
+    assert_equal false, new_document.encrypted_flag
+  end
+
+  test "should download non-encrypted document" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    document = Document.create!(
+      title: 'Download Test',
+      document_date: Date.today,
+      document_url: 'download_test.pdf',
+      user: @non_encrypted_user,
+      encrypted_flag: false
+    )
+    
+    File.write(Settings.document_folder + 'download_test.pdf', @test_pdf_content, mode: 'w+b')
+    
+    get :download, params: { id: document.id }
+    
+    assert_response :success
+    assert_equal 'application/pdf', @response.content_type
+    assert_equal @test_pdf_content, @response.body
+    
+    File.delete(Settings.document_folder + 'download_test.pdf') if File.exist?(Settings.document_folder + 'download_test.pdf')
+    document.destroy
+  end
+
+  test "should download and decrypt encrypted document" do
+    @request.headers['Authorization'] = "Bearer #{@token_with_encryption}"
+    
+    lockbox = Lockbox.new(key: @encrypted_user.secret_key)
+    encrypted_content = lockbox.encrypt(@test_pdf_content)
+    
+    document = Document.create!(
+      title: 'Encrypted Download Test',
+      document_date: Date.today,
+      document_url: 'encrypted_download_test.pdf',
+      user: @encrypted_user,
+      encrypted_flag: true
+    )
+    
+    File.write(Settings.document_folder + 'encrypted_download_test.pdf', encrypted_content, mode: 'w+b')
+    
+    get :download, params: { id: document.id }
+    
+    assert_response :success
+    assert_equal 'application/pdf', @response.content_type
+    assert_equal @test_pdf_content, @response.body
+    
+    File.delete(Settings.document_folder + 'encrypted_download_test.pdf') if File.exist?(Settings.document_folder + 'encrypted_download_test.pdf')
+    document.destroy
+  end
+
+  test "should return unauthorized without token" do
+    post :create, params: {
+      title: 'Test',
+      document_date: Date.today.to_s
+    }
+    
+    assert_response :unauthorized
+  end
 end

--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -1,21 +1,23 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  title: MyString
-  description: MyText
+  title: Non Encrypted Document
+  description: A non-encrypted test document
   document_date: 2019-05-25
-  document_url: MyString
-  version: 9.99
+  document_url: test1.pdf
+  version: 1.0
   folder_id: 
-  user_id: 
+  user_id: one
   state_id: 
+  encrypted_flag: false
 
 two:
-  title: MyString
-  description: MyText
+  title: Encrypted Document
+  description: An encrypted test document
   document_date: 2019-05-25
-  document_url: MyString
-  version: 9.99
+  document_url: test2.pdf
+  version: 1.0
   folder_id: 
-  user_id: 
+  user_id: two
   state_id: 
+  encrypted_flag: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,15 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
-  password_digest: MyString
-  email: MyString
+  name: Non Encrypted User
+  password_digest: <%= BCrypt::Password.create('password123') %>
+  email: non_encrypted@example.com
+  encryption_actived_flag: false
+  secret_key: null
 
 two:
-  name: MyString
-  password_digest: MyString
-  email: MyString
+  name: Encrypted User
+  password_digest: <%= BCrypt::Password.create('password123') %>
+  email: encrypted@example.com
+  encryption_actived_flag: true
+  secret_key: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef


### PR DESCRIPTION
添加PDF文件验证和错误处理

增加对上传文件的验证，包括文件是否为空、是否为PDF格式

当验证失败时返回422状态码和错误信息

同时完善测试用例以覆盖这些验证逻辑