### PR TITLE
.2059806565729300:80bc4f6f2ed959a15f62cf5a59b6589a_69de061a949d52b384860bc4.69e43628b13256d09ece83f3.69e43628dc688667809240d9:Trae CN.T(2026/4/19 09:55:52)

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -24,11 +24,11 @@ class DocumentsController < ApplicationController
       @file_name = nil
     else
       @file_name = SecureRandom.uuid + '.pdf'
+      data = @file.read
 
       if @encrypted
         lockbox = Lockbox.new(key: current_user.secret_key)
 
-        data = @file.read
         encrypted_data = lockbox.encrypt(data)
         File.write(Settings.document_folder + @file_name, encrypted_data, mode: 'w+b')
       else

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -4,12 +4,10 @@ class DocumentsController < ApplicationController
 
   # GET /documents
   def index
-    @start_index = 0
-    if (!params[:page].blank?)
-      @start_index = (convert_to_int(params[:page]) - 1) * 20
-    end
-    @end_index = @start_index + 19
-    @documents = @documents[@start_index..@end_index]
+    page = params[:page].blank? ? 1 : convert_to_int(params[:page])
+    page = 1 if page.nil? || page < 1
+    
+    @documents = @documents.offset((page - 1) * 20).limit(20)
 
     json_response(@documents)
   end
@@ -136,8 +134,8 @@ class DocumentsController < ApplicationController
 
   # GET /documents/pages
   def page_count
-    @document_count = @documents.length()
-    @page_count = (@document_count/20.to_f).ceil
+    @document_count = @documents.count
+    @page_count = (@document_count / 20.0).ceil
     json_response(page_count: @page_count)
   end
 
@@ -155,18 +153,27 @@ class DocumentsController < ApplicationController
   def set_documents
     @documents = current_user.documents.order(document_date: :desc)
 
-    if (!params[:folder_filter].blank?)
-      @documents = @documents.select { |d| d.folder_id == convert_to_int(params[:folder_filter])}
-    end
-    if (!params[:state_filter].blank?)
-      @documents = @documents.select { |d| d.state_id == convert_to_int(params[:state_filter])}
-    end
-    if (!params[:person_filter].blank?)
-      @documents = @documents.select { |d| d.person_id == convert_to_int(params[:person_filter])}
-    end
-    if (!params[:search].blank?)
-      @search = params[:search].to_s.downcase.delete(' ')
-      @documents = @documents.select { |d| (d.title.downcase.delete(' ').include?(@search) or (!d.description.nil? and d.description.downcase.delete(' ').include?(@search)) or (!d.document_text.nil? and d.document_text.downcase.delete(' ').include?(@search)))}
+    folder_id = convert_to_int(params[:folder_filter]) if !params[:folder_filter].blank?
+    state_id = convert_to_int(params[:state_filter]) if !params[:state_filter].blank?
+    person_id = convert_to_int(params[:person_filter]) if !params[:person_filter].blank?
+
+    @documents = @documents.where(folder_id: folder_id) if folder_id
+    @documents = @documents.where(state_id: state_id) if state_id
+    @documents = @documents.where(person_id: person_id) if person_id
+
+    if !params[:search].blank?
+      search_term = params[:search].to_s.downcase.delete(' ')
+      
+      if search_term.present?
+        search_pattern = "%#{search_term}%"
+        
+        @documents = @documents.where(
+          "LOWER(REPLACE(title, ' ', '')) LIKE :search OR 
+           (LOWER(REPLACE(description, ' ', '')) LIKE :search AND description IS NOT NULL) OR 
+           (LOWER(REPLACE(document_text, ' ', '')) LIKE :search AND document_text IS NOT NULL)",
+          search: search_pattern
+        )
+      end
     end
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -21,35 +21,52 @@ class DocumentsController < ApplicationController
     @encrypted = current_user.encryption_actived_flag? and current_user.secret_key.present?
 
     if @file.blank?
-      @file_name = nil
+      json_response({ message: "Document file is required" }, :unprocessable_entity)
+      return
+    end
+
+    data = @file.read
+    if data.nil? || data.empty?
+      json_response({ message: "Document file cannot be empty" }, :unprocessable_entity)
+      return
+    end
+
+    content_type = @file.content_type.to_s
+    original_filename = @file.original_filename.to_s
+    is_pdf = content_type == 'application/pdf' || 
+             content_type == 'application/octet-stream' ||
+             original_filename.end_with?('.pdf')
+
+    unless is_pdf
+      json_response({ message: "Only PDF documents are allowed" }, :unprocessable_entity)
+      return
+    end
+
+    @file_name = SecureRandom.uuid + '.pdf'
+
+    if @encrypted
+      lockbox = Lockbox.new(key: current_user.secret_key)
+      encrypted_data = lockbox.encrypt(data)
+      File.write(Settings.document_folder + @file_name, encrypted_data, mode: 'w+b')
+      @file_text = ""
     else
-      @file_name = SecureRandom.uuid + '.pdf'
-      data = @file.read
+      File.write(Settings.document_folder + @file_name, data, mode: 'w+b')
 
-      if @encrypted
-        lockbox = Lockbox.new(key: current_user.secret_key)
+      begin
+        reader = PDF::Reader.new(Settings.document_folder + @file_name)
+        reader.pages.each do |page|
+          @file_text = @file_text + page.text
+        end
 
-        encrypted_data = lockbox.encrypt(data)
-        File.write(Settings.document_folder + @file_name, encrypted_data, mode: 'w+b')
-      else
-        File.write(Settings.document_folder + @file_name, data, mode: 'w+b')
+        @file_text.delete!("\r\n")
+        @file_text.delete!("\n")
+        @file_text.delete!(' ')
 
-        begin
-          reader = PDF::Reader.new(Settings.document_folder + @file_name)
-          reader.pages.each do |page|
-            @file_text = @file_text + page.text
-          end
-
-          @file_text.delete!("\r\n")
-          @file_text.delete!("\n")
-          @file_text.delete!(' ')
-
-          if @file_text.bytesize > 65535
-            @file_text = ""
-          end
-        rescue PDF::Reader::MalformedPDFError, PDF::Reader::EncryptedPDFError
+        if @file_text.bytesize > 65535
           @file_text = ""
         end
+      rescue PDF::Reader::MalformedPDFError, PDF::Reader::EncryptedPDFError
+        @file_text = ""
       end
     end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,13 +1,15 @@
 class DocumentsController < ApplicationController
+  PAGE_SIZE = 20
+
   before_action :set_document, only: [:show, :download, :update, :destroy]
   before_action :set_documents, only: [:index, :page_count]
 
   # GET /documents
   def index
-    page = params[:page].blank? ? 1 : convert_to_int(params[:page])
-    page = 1 if page.nil? || page < 1
+    page = parse_page_param(params[:page])
+    offset = (page - 1) * PAGE_SIZE
     
-    @documents = @documents.offset((page - 1) * 20).limit(20)
+    @documents = @documents.offset(offset).limit(PAGE_SIZE)
 
     json_response(@documents)
   end
@@ -134,16 +136,37 @@ class DocumentsController < ApplicationController
 
   # GET /documents/pages
   def page_count
-    @document_count = @documents.count
-    @page_count = (@document_count / 20.0).ceil
-    json_response(page_count: @page_count)
+    document_count = @documents.count
+    page_count_value = (document_count.to_f / PAGE_SIZE).ceil
+    json_response(page_count: page_count_value)
   end
 
   private
 
-  def convert_to_int(string)
-    num = string.to_i
-    num if num.to_s == string
+  def parse_page_param(page_param)
+    return 1 if page_param.blank?
+    
+    page = parse_positive_integer(page_param)
+    page.nil? || page < 1 ? 1 : page
+  end
+
+  def parse_positive_integer(string)
+    return nil if string.blank?
+    
+    stripped = string.to_s.strip
+    return nil if stripped.empty?
+    
+    if stripped.match?(/\A\d+\z/)
+      num = stripped.to_i
+      num > 0 ? num : nil
+    else
+      nil
+    end
+  end
+
+  def parse_filter_id(filter_param)
+    return nil if filter_param.blank?
+    parse_positive_integer(filter_param)
   end
 
   def set_document
@@ -153,9 +176,9 @@ class DocumentsController < ApplicationController
   def set_documents
     @documents = current_user.documents.order(document_date: :desc)
 
-    folder_id = convert_to_int(params[:folder_filter]) if !params[:folder_filter].blank?
-    state_id = convert_to_int(params[:state_filter]) if !params[:state_filter].blank?
-    person_id = convert_to_int(params[:person_filter]) if !params[:person_filter].blank?
+    folder_id = parse_filter_id(params[:folder_filter])
+    state_id = parse_filter_id(params[:state_filter])
+    person_id = parse_filter_id(params[:person_filter])
 
     @documents = @documents.where(folder_id: folder_id) if folder_id
     @documents = @documents.where(state_id: state_id) if state_id

--- a/db/migrate/20260419000001_add_composite_indexes_to_documents.rb
+++ b/db/migrate/20260419000001_add_composite_indexes_to_documents.rb
@@ -1,0 +1,8 @@
+class AddCompositeIndexesToDocuments < ActiveRecord::Migration[7.1]
+  def change
+    add_index :documents, [:user_id, :document_date], name: 'index_documents_on_user_id_and_document_date'
+    add_index :documents, [:user_id, :folder_id, :document_date], name: 'index_documents_on_user_id_and_folder_id_and_document_date'
+    add_index :documents, [:user_id, :state_id, :document_date], name: 'index_documents_on_user_id_and_state_id_and_document_date'
+    add_index :documents, [:user_id, :person_id, :document_date], name: 'index_documents_on_user_id_and_person_id_and_document_date'
+  end
+end

--- a/test/controllers/documents_controller_test.rb
+++ b/test/controllers/documents_controller_test.rb
@@ -9,7 +9,7 @@ class DocumentsControllerTest < ActionController::TestCase
     @token_without_encryption = JsonWebToken.encode(user_id: @non_encrypted_user.id)
     @token_with_encryption = JsonWebToken.encode(user_id: @encrypted_user.id)
     
-    @test_pdf_content = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \ntrailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n192\n%%EOF"
+    @test_pdf_content = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>\nendobj\n4 0 obj\n<< /Length 44 >>\nstream\nBT\n/F1 24 Tf\n100 700 Td\n(Hello World) Tj\nET\nendstream\nendobj\nxref\n0 5\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \n0000000208 00000 n \ntrailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n310\n%%EOF"
   end
 
   test "should create document without encryption for non-encrypted user" do
@@ -84,10 +84,10 @@ class DocumentsControllerTest < ActionController::TestCase
     temp_file.unlink
   end
 
-  test "should create document without file (empty document)" do
+  test "should return 422 when document is not provided" do
     @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
     
-    assert_difference('Document.count') do
+    assert_no_difference('Document.count') do
       post :create, params: {
         title: 'Empty Document',
         description: 'Document without file',
@@ -95,12 +95,122 @@ class DocumentsControllerTest < ActionController::TestCase
       }
     end
     
+    assert_response :unprocessable_entity
+    
+    json_response = JSON.parse(@response.body)
+    assert_includes json_response['message'], 'required'
+  end
+
+  test "should return 422 when document file is empty" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    temp_file = Tempfile.new(['empty', '.pdf'])
+    temp_file.write('')
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_no_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Empty File Document',
+        description: 'Empty file',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :unprocessable_entity
+    
+    json_response = JSON.parse(@response.body)
+    assert_includes json_response['message'], 'empty'
+    
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "should return 422 when document is not a PDF" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.txt'])
+    temp_file.write('This is a text file, not a PDF')
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'text/plain')
+    
+    assert_no_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Text Document',
+        description: 'This is not a PDF',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :unprocessable_entity
+    
+    json_response = JSON.parse(@response.body)
+    assert_includes json_response['message'], 'PDF'
+    
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "non-encrypted document should have document_text extracted" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.pdf'])
+    temp_file.write(@test_pdf_content)
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Document With Text',
+        description: 'Test text extraction',
+        document_date: Date.today.to_s
+      }
+    end
+    
     assert_response :created
     
     new_document = Document.last
-    assert_equal 'Empty Document', new_document.title
-    assert_nil new_document.document_url
     assert_equal false, new_document.encrypted_flag
+    assert_not_empty new_document.document_text
+    
+    File.delete(Settings.document_folder + new_document.document_url) if File.exist?(Settings.document_folder + new_document.document_url)
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "encrypted document should have empty document_text" do
+    @request.headers['Authorization'] = "Bearer #{@token_with_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.pdf'])
+    temp_file.write(@test_pdf_content)
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Encrypted Document With Text',
+        description: 'Encrypted, text should be empty',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :created
+    
+    new_document = Document.last
+    assert_equal true, new_document.encrypted_flag
+    assert_empty new_document.document_text
+    
+    File.delete(Settings.document_folder + new_document.document_url) if File.exist?(Settings.document_folder + new_document.document_url)
+    temp_file.close
+    temp_file.unlink
   end
 
   test "should download non-encrypted document" do

--- a/test/controllers/documents_controller_test.rb
+++ b/test/controllers/documents_controller_test.rb
@@ -4,7 +4,13 @@ class DocumentsControllerTest < ActionController::TestCase
   setup do
     @non_encrypted_user = users(:one)
     @encrypted_user = users(:two)
-    @document = documents(:one)
+    
+    @work_folder = folders(:work)
+    @personal_folder = folders(:personal)
+    @draft_state = states(:draft)
+    @review_state = states(:review)
+    @john_person = people(:john)
+    @jane_person = people(:jane)
     
     @token_without_encryption = JsonWebToken.encode(user_id: @non_encrypted_user.id)
     @token_with_encryption = JsonWebToken.encode(user_id: @encrypted_user.id)
@@ -12,6 +18,8 @@ class DocumentsControllerTest < ActionController::TestCase
     @test_pdf_content = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>\nendobj\n4 0 obj\n<< /Length 44 >>\nstream\nBT\n/F1 24 Tf\n100 700 Td\n(Hello World) Tj\nET\nendstream\nendobj\nxref\n0 5\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \n0000000208 00000 n \ntrailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n310\n%%EOF"
   end
 
+  # ==================== Create Tests ====================
+  
   test "should create document without encryption for non-encrypted user" do
     @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
     
@@ -213,6 +221,8 @@ class DocumentsControllerTest < ActionController::TestCase
     temp_file.unlink
   end
 
+  # ==================== Download Tests ====================
+
   test "should download non-encrypted document" do
     @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
     
@@ -262,6 +272,216 @@ class DocumentsControllerTest < ActionController::TestCase
     document.destroy
   end
 
+  # ==================== Filter Tests (ActiveRecord Queries) ====================
+
+  test "should filter documents by folder" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { folder_filter: @work_folder.id }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 2, documents.length
+    
+    titles = documents.map { |d| d['title'] }
+    assert_includes titles, 'Work Report 2024'
+    assert_includes titles, 'Project Proposal'
+    assert_not_includes titles, 'Personal Notes'
+  end
+
+  test "should filter documents by state" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { state_filter: @draft_state.id }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 2, documents.length
+    
+    titles = documents.map { |d| d['title'] }
+    assert_includes titles, 'Work Report 2024'
+    assert_includes titles, 'Personal Notes'
+    assert_not_includes titles, 'Project Proposal'
+  end
+
+  test "should filter documents by folder and state" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { 
+      folder_filter: @work_folder.id,
+      state_filter: @draft_state.id
+    }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 1, documents.length
+    assert_equal 'Work Report 2024', documents.first['title']
+  end
+
+  # ==================== Search Tests (ActiveRecord Queries) ====================
+
+  test "should search documents by title" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { search: 'Work Report' }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 1, documents.length
+    assert_equal 'Work Report 2024', documents.first['title']
+  end
+
+  test "should search documents by description" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { search: 'personal document' }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 1, documents.length
+    assert_equal 'Personal Notes', documents.first['title']
+  end
+
+  test "should search documents by document_text" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { search: 'projectproposalq1' }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 1, documents.length
+    assert_equal 'Project Proposal', documents.first['title']
+  end
+
+  test "search should ignore spaces" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { search: 'Project  Proposal  Q1' }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 1, documents.length
+    assert_equal 'Project Proposal', documents.first['title']
+  end
+
+  test "search should be case insensitive" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { search: 'work report' }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 1, documents.length
+    assert_equal 'Work Report 2024', documents.first['title']
+  end
+
+  test "search with no matches should return empty array" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { search: 'nonexistentkeyword123456' }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 0, documents.length
+  end
+
+  # ==================== Pagination Tests (ActiveRecord Queries) ====================
+
+  test "pagination should work correctly with filtered results" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    25.times do |i|
+      Document.create!(
+        title: "Pagination Test #{i + 1}",
+        document_date: Date.today - i.days,
+        document_url: "page_test_#{i}.pdf",
+        user: @non_encrypted_user,
+        encrypted_flag: false,
+        folder: @work_folder
+      )
+    end
+    
+    get :index, params: { folder_filter: @work_folder.id, page: 1 }
+    
+    assert_response :success
+    page1 = JSON.parse(@response.body)
+    assert_equal 20, page1.length
+    
+    get :index, params: { folder_filter: @work_folder.id, page: 2 }
+    
+    assert_response :success
+    page2 = JSON.parse(@response.body)
+    assert_equal 5, page2.length
+    
+    Document.where(folder_id: @work_folder.id).where('title LIKE ?', 'Pagination Test%').destroy_all
+  end
+
+  test "page_count should reflect filtered results" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    25.times do |i|
+      Document.create!(
+        title: "Page Count Test #{i + 1}",
+        document_date: Date.today - i.days,
+        document_url: "count_test_#{i}.pdf",
+        user: @non_encrypted_user,
+        encrypted_flag: false,
+        folder: @work_folder
+      )
+    end
+    
+    get :page_count, params: { folder_filter: @work_folder.id }
+    
+    assert_response :success
+    result = JSON.parse(@response.body)
+    
+    assert_equal 2, result['page_count']
+    
+    Document.where(folder_id: @work_folder.id).where('title LIKE ?', 'Page Count Test%').destroy_all
+  end
+
+  test "page 0 should default to page 1" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { page: 0 }
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    assert_not_empty documents
+  end
+
+  test "negative page should default to page 1" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { page: -1 }
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    assert_not_empty documents
+  end
+
+  # ==================== Security Tests ====================
+
   test "should return unauthorized without token" do
     post :create, params: {
       title: 'Test',
@@ -269,5 +489,38 @@ class DocumentsControllerTest < ActionController::TestCase
     }
     
     assert_response :unauthorized
+  end
+
+  test "should return unauthorized for index without token" do
+    get :index
+    
+    assert_response :unauthorized
+  end
+
+  test "user should only see own documents" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    user_ids = documents.map { |d| d['user']['id'] }.uniq
+    assert_equal [@non_encrypted_user.id], user_ids
+    assert_not_includes documents.map { |d| d['title'] }, 'Encrypted Invoice'
+  end
+
+  # ==================== Order Tests ====================
+
+  test "documents should be ordered by document_date descending" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    dates = documents.map { |d| Date.parse(d['document_date']) }
+    assert_equal dates.sort.reverse, dates
   end
 end

--- a/test/controllers/documents_controller_test.rb
+++ b/test/controllers/documents_controller_test.rb
@@ -1,7 +1,163 @@
 require 'test_helper'
 
 class DocumentsControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @non_encrypted_user = users(:one)
+    @encrypted_user = users(:two)
+    @document = documents(:one)
+    
+    @token_without_encryption = JsonWebToken.encode(user_id: @non_encrypted_user.id)
+    @token_with_encryption = JsonWebToken.encode(user_id: @encrypted_user.id)
+    
+    @test_pdf_content = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \ntrailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n192\n%%EOF"
+  end
+
+  test "should create document without encryption for non-encrypted user" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.pdf'])
+    temp_file.write(@test_pdf_content)
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Test Document',
+        description: 'Test description',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :created
+    
+    new_document = Document.last
+    assert_equal false, new_document.encrypted_flag
+    assert_equal 'Test Document', new_document.title
+    
+    assert File.exist?(Settings.document_folder + new_document.document_url)
+    
+    stored_content = File.read(Settings.document_folder + new_document.document_url)
+    assert_equal @test_pdf_content, stored_content
+    
+    File.delete(Settings.document_folder + new_document.document_url) if File.exist?(Settings.document_folder + new_document.document_url)
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "should create document with encryption for encrypted user" do
+    @request.headers['Authorization'] = "Bearer #{@token_with_encryption}"
+    
+    temp_file = Tempfile.new(['test', '.pdf'])
+    temp_file.write(@test_pdf_content)
+    temp_file.rewind
+    
+    uploaded_file = Rack::Test::UploadedFile.new(temp_file.path, 'application/pdf')
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        document: uploaded_file,
+        title: 'Encrypted Test Document',
+        description: 'Encrypted test description',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :created
+    
+    new_document = Document.last
+    assert_equal true, new_document.encrypted_flag
+    assert_equal 'Encrypted Test Document', new_document.title
+    
+    assert File.exist?(Settings.document_folder + new_document.document_url)
+    
+    stored_content = File.read(Settings.document_folder + new_document.document_url)
+    assert_not_equal @test_pdf_content, stored_content
+    
+    lockbox = Lockbox.new(key: @encrypted_user.secret_key)
+    decrypted_content = lockbox.decrypt(stored_content)
+    assert_equal @test_pdf_content, decrypted_content
+    
+    File.delete(Settings.document_folder + new_document.document_url) if File.exist?(Settings.document_folder + new_document.document_url)
+    temp_file.close
+    temp_file.unlink
+  end
+
+  test "should create document without file (empty document)" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    assert_difference('Document.count') do
+      post :create, params: {
+        title: 'Empty Document',
+        description: 'Document without file',
+        document_date: Date.today.to_s
+      }
+    end
+    
+    assert_response :created
+    
+    new_document = Document.last
+    assert_equal 'Empty Document', new_document.title
+    assert_nil new_document.document_url
+    assert_equal false, new_document.encrypted_flag
+  end
+
+  test "should download non-encrypted document" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    document = Document.create!(
+      title: 'Download Test',
+      document_date: Date.today,
+      document_url: 'download_test.pdf',
+      user: @non_encrypted_user,
+      encrypted_flag: false
+    )
+    
+    File.write(Settings.document_folder + 'download_test.pdf', @test_pdf_content, mode: 'w+b')
+    
+    get :download, params: { id: document.id }
+    
+    assert_response :success
+    assert_equal 'application/pdf', @response.content_type
+    assert_equal @test_pdf_content, @response.body
+    
+    File.delete(Settings.document_folder + 'download_test.pdf') if File.exist?(Settings.document_folder + 'download_test.pdf')
+    document.destroy
+  end
+
+  test "should download and decrypt encrypted document" do
+    @request.headers['Authorization'] = "Bearer #{@token_with_encryption}"
+    
+    lockbox = Lockbox.new(key: @encrypted_user.secret_key)
+    encrypted_content = lockbox.encrypt(@test_pdf_content)
+    
+    document = Document.create!(
+      title: 'Encrypted Download Test',
+      document_date: Date.today,
+      document_url: 'encrypted_download_test.pdf',
+      user: @encrypted_user,
+      encrypted_flag: true
+    )
+    
+    File.write(Settings.document_folder + 'encrypted_download_test.pdf', encrypted_content, mode: 'w+b')
+    
+    get :download, params: { id: document.id }
+    
+    assert_response :success
+    assert_equal 'application/pdf', @response.content_type
+    assert_equal @test_pdf_content, @response.body
+    
+    File.delete(Settings.document_folder + 'encrypted_download_test.pdf') if File.exist?(Settings.document_folder + 'encrypted_download_test.pdf')
+    document.destroy
+  end
+
+  test "should return unauthorized without token" do
+    post :create, params: {
+      title: 'Test',
+      document_date: Date.today.to_s
+    }
+    
+    assert_response :unauthorized
+  end
 end

--- a/test/controllers/documents_controller_test.rb
+++ b/test/controllers/documents_controller_test.rb
@@ -324,6 +324,42 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_equal 'Work Report 2024', documents.first['title']
   end
 
+  test "invalid filter ID should be ignored" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { folder_filter: 'abc' }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 3, documents.length
+  end
+
+  test "negative filter ID should be ignored" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { folder_filter: '-1' }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 3, documents.length
+  end
+
+  test "zero filter ID should be ignored" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { folder_filter: '0' }
+    
+    assert_response :success
+    
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 3, documents.length
+  end
+
   # ==================== Search Tests (ActiveRecord Queries) ====================
 
   test "should search documents by title" do
@@ -403,7 +439,7 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_equal 0, documents.length
   end
 
-  # ==================== Pagination Tests (ActiveRecord Queries) ====================
+  # ==================== Pagination Tests (Unified Logic) ====================
 
   test "pagination should work correctly with filtered results" do
     @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
@@ -458,10 +494,44 @@ class DocumentsControllerTest < ActionController::TestCase
     Document.where(folder_id: @work_folder.id).where('title LIKE ?', 'Page Count Test%').destroy_all
   end
 
+  test "no page param should default to page 1" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    3.times do |i|
+      Document.create!(
+        title: "Default Page Test #{i + 1}",
+        document_date: Date.today - i.days,
+        document_url: "default_test_#{i}.pdf",
+        user: @non_encrypted_user,
+        encrypted_flag: false
+      )
+    end
+    
+    get :index
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 6, documents.length
+    
+    Document.where('title LIKE ?', 'Default Page Test%').destroy_all
+  end
+
   test "page 0 should default to page 1" do
     @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
     
     get :index, params: { page: 0 }
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    assert_not_empty documents
+  end
+
+  test "page 0 as string should default to page 1" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { page: '0' }
     
     assert_response :success
     documents = JSON.parse(@response.body)
@@ -480,6 +550,123 @@ class DocumentsControllerTest < ActionController::TestCase
     assert_not_empty documents
   end
 
+  test "negative page as string should default to page 1" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { page: '-5' }
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    assert_not_empty documents
+  end
+
+  test "non-numeric page should default to page 1" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { page: 'abc' }
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    assert_not_empty documents
+  end
+
+  test "page with decimal should default to page 1" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { page: '1.5' }
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    assert_not_empty documents
+  end
+
+  test "page with special chars should default to page 1" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    get :index, params: { page: '1abc' }
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    assert_not_empty documents
+  end
+
+  test "page beyond total pages should return empty array" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    5.times do |i|
+      Document.create!(
+        title: "Beyond Test #{i + 1}",
+        document_date: Date.today - i.days,
+        document_url: "beyond_test_#{i}.pdf",
+        user: @non_encrypted_user,
+        encrypted_flag: false
+      )
+    end
+    
+    get :index, params: { page: 100 }
+    
+    assert_response :success
+    documents = JSON.parse(@response.body)
+    
+    assert_equal 0, documents.length
+    
+    Document.where('title LIKE ?', 'Beyond Test%').destroy_all
+  end
+
+  test "page_count with invalid page should still return correct count" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    5.times do |i|
+      Document.create!(
+        title: "Count Invalid Test #{i + 1}",
+        document_date: Date.today - i.days,
+        document_url: "count_invalid_test_#{i}.pdf",
+        user: @non_encrypted_user,
+        encrypted_flag: false
+      )
+    end
+    
+    get :page_count, params: { page: 'invalid' }
+    
+    assert_response :success
+    result = JSON.parse(@response.body)
+    
+    assert_equal 1, result['page_count']
+    
+    Document.where('title LIKE ?', 'Count Invalid Test%').destroy_all
+  end
+
+  test "index and page_count should use same query logic with filters" do
+    @request.headers['Authorization'] = "Bearer #{@token_without_encryption}"
+    
+    10.times do |i|
+      Document.create!(
+        title: "Consistency Test #{i + 1}",
+        document_date: Date.today - i.days,
+        document_url: "consistency_test_#{i}.pdf",
+        user: @non_encrypted_user,
+        encrypted_flag: false,
+        folder: @work_folder
+      )
+    end
+    
+    get :page_count, params: { folder_filter: @work_folder.id }
+    page_count_result = JSON.parse(@response.body)
+    total_pages = page_count_result['page_count']
+    
+    get :index, params: { folder_filter: @work_folder.id, page: 1 }
+    index_result = JSON.parse(@response.body)
+    
+    assert_equal 1, total_pages
+    assert_equal 12, index_result.length
+    
+    Document.where(folder_id: @work_folder.id).where('title LIKE ?', 'Consistency Test%').destroy_all
+  end
+
   # ==================== Security Tests ====================
 
   test "should return unauthorized without token" do
@@ -493,6 +680,12 @@ class DocumentsControllerTest < ActionController::TestCase
 
   test "should return unauthorized for index without token" do
     get :index
+    
+    assert_response :unauthorized
+  end
+
+  test "should return unauthorized for page_count without token" do
+    get :page_count
     
     assert_response :unauthorized
   end

--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -1,23 +1,49 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  title: Non Encrypted Document
-  description: A non-encrypted test document
-  document_date: 2019-05-25
-  document_url: test1.pdf
+doc_work_draft:
+  title: Work Report 2024
+  description: Annual work report document
+  document_date: 2024-01-15
+  document_url: report_2024.pdf
   version: 1.0
-  folder_id: 
   user_id: one
-  state_id: 
+  folder_id: work
+  state_id: draft
   encrypted_flag: false
+  document_text: annualworkreport2024summary
 
-two:
-  title: Encrypted Document
-  description: An encrypted test document
-  document_date: 2019-05-25
-  document_url: test2.pdf
+doc_work_review:
+  title: Project Proposal
+  description: New project proposal for Q1
+  document_date: 2024-02-20
+  document_url: proposal.pdf
   version: 1.0
-  folder_id: 
+  user_id: one
+  folder_id: work
+  state_id: review
+  encrypted_flag: false
+  document_text: projectproposalq12024
+
+doc_personal:
+  title: Personal Notes
+  description: My personal document
+  document_date: 2024-03-10
+  document_url: notes.pdf
+  version: 1.0
+  user_id: one
+  folder_id: personal
+  state_id: draft
+  encrypted_flag: false
+  document_text: personaldocumentnotes
+
+doc_encrypted:
+  title: Encrypted Invoice
+  description: Confidential invoice
+  document_date: 2024-04-01
+  document_url: invoice.pdf
+  version: 1.0
   user_id: two
-  state_id: 
+  folder_id: invoices
+  state_id: completed
   encrypted_flag: true
+  document_text: ""

--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -1,21 +1,23 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  title: MyString
-  description: MyText
+  title: Non Encrypted Document
+  description: A non-encrypted test document
   document_date: 2019-05-25
-  document_url: MyString
-  version: 9.99
+  document_url: test1.pdf
+  version: 1.0
   folder_id: 
-  user_id: 
+  user_id: one
   state_id: 
+  encrypted_flag: false
 
 two:
-  title: MyString
-  description: MyText
+  title: Encrypted Document
+  description: An encrypted test document
   document_date: 2019-05-25
-  document_url: MyString
-  version: 9.99
+  document_url: test2.pdf
+  version: 1.0
   folder_id: 
-  user_id: 
+  user_id: two
   state_id: 
+  encrypted_flag: true

--- a/test/fixtures/folders.yml
+++ b/test/fixtures/folders.yml
@@ -1,11 +1,13 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
-  folder_id: 
-  user_id: 
+work:
+  name: Work
+  user_id: one
 
-two:
-  name: MyString
-  folder_id: 
-  user_id: 
+personal:
+  name: Personal
+  user_id: one
+
+invoices:
+  name: Invoices
+  user_id: two

--- a/test/fixtures/people.yml
+++ b/test/fixtures/people.yml
@@ -1,9 +1,13 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
-  user: 
+john:
+  name: John Doe
+  user_id: one
 
-two:
-  name: MyString
-  user: 
+jane:
+  name: Jane Smith
+  user_id: one
+
+accounting:
+  name: Accounting Department
+  user_id: two

--- a/test/fixtures/states.yml
+++ b/test/fixtures/states.yml
@@ -1,7 +1,13 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
+draft:
+  name: Draft
+  user_id: one
 
-two:
-  name: MyString
+review:
+  name: Review
+  user_id: one
+
+completed:
+  name: Completed
+  user_id: two

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,15 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
-  password_digest: MyString
-  email: MyString
+  name: Non Encrypted User
+  password_digest: <%= BCrypt::Password.create('password123') %>
+  email: non_encrypted@example.com
+  encryption_actived_flag: false
+  secret_key: null
 
 two:
-  name: MyString
-  password_digest: MyString
-  email: MyString
+  name: Encrypted User
+  password_digest: <%= BCrypt::Password.create('password123') %>
+  email: encrypted@example.com
+  encryption_actived_flag: true
+  secret_key: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef


### PR DESCRIPTION
重构分页和过滤参数处理逻辑

将分页和过滤参数的处理逻辑拆分为独立方法，提高代码可读性和可维护性

添加对无效分页和过滤参数的测试用例

使用常量定义分页大小，避免硬编码